### PR TITLE
Hotfix Issue 1

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.abeade.plugin.fcm.push</id>
   <name>FCM push sender</name>
-  <version>0.5</version>
+  <version>0.5.1</version>
   <vendor email="albert.beade@letgo.com" url="https://github.com/abeade">Albert Beade</vendor>
 
   <description><![CDATA[
@@ -10,6 +10,10 @@
     ]]></description>
 
   <change-notes><![CDATA[
+      <b>0.5.1</b>
+      <ul>
+        <li>Uses default project at settings panel</li>
+      </ul>
       <b>0.5</b>
       <ul>
         <li>Allows to disable stetho integration</li>

--- a/src/com/abeade/plugin/fcm/push/PushDialogWrapper.kt
+++ b/src/com/abeade/plugin/fcm/push/PushDialogWrapper.kt
@@ -63,7 +63,7 @@ class PushDialogWrapper(
         val firebaseId = firebaseIdFromSharedPreference ?: propertiesComponent.getValue(PushDialogWrapper.FIREBASE_KEY).orEmpty()
         val data = propertiesComponent.getValue(PushDialogWrapper.DATA_KEY).orEmpty()
         val saveKey = propertiesComponent.getBoolean(SAVE_KEY)
-        val templates = listOf("") + settingsManager.templates.map { it.name }.filterNotNull().toList()
+        val templates = listOf("") + settingsManager.templates.map { it.name }.toList()
         firebaseIdField = JTextField(firebaseId)
         dataField = CustomEditorField(JsonLanguage.INSTANCE, project, data)
         rememberCheckBox = JCheckBox().apply { isSelected = saveKey }

--- a/src/com/abeade/plugin/fcm/push/settings/PushSettingsConfigurable.kt
+++ b/src/com/abeade/plugin/fcm/push/settings/PushSettingsConfigurable.kt
@@ -4,25 +4,28 @@ import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import javax.swing.JComponent
 
-class PushSettingsConfigurable(project: Project) : SearchableConfigurable {
+class PushSettingsConfigurable(private val project: Project) : SearchableConfigurable {
 
-    private val panel = PushSettingsPanel(project)
+    private var panel: PushSettingsPanel? = null
 
     override fun getDisplayName(): String? = "FCM push sender"
 
     override fun getHelpTopic(): String? = "FCM push sender"
 
-    override fun createComponent(): JComponent? = panel
+    override fun createComponent(): JComponent? {
+        panel = PushSettingsPanel(project)
+        return panel
+    }
 
-    override fun isModified(): Boolean = panel.isModified
+    override fun isModified(): Boolean = panel?.isModified == true
 
     override fun getId(): String = "FCM push sender"
 
     override fun apply() {
-        panel.apply()
+        panel?.apply()
     }
 
     override fun reset() {
-        panel.reset()
+        panel?.reset()
     }
 }

--- a/src/com/abeade/plugin/fcm/push/settings/PushSettingsPanel.kt
+++ b/src/com/abeade/plugin/fcm/push/settings/PushSettingsPanel.kt
@@ -10,6 +10,7 @@ import com.google.gson.stream.JsonReader
 import com.intellij.icons.AllIcons
 import com.intellij.json.JsonLanguage
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.ui.CollectionListModel
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.ToolbarDecorator
@@ -73,7 +74,7 @@ class PushSettingsPanel(project: Project) : JPanel() {
         }
     }
     private val templateNameField = JTextField()
-    private val templateDataField = CustomEditorField(JsonLanguage.INSTANCE, project, String.EMPTY)
+    private val templateDataField = CustomEditorField(JsonLanguage.INSTANCE, ProjectManager.getInstance().defaultProject, String.EMPTY)
     private val exportButton = JButton("Export").apply {
         icon = AllIcons.Actions.Download
         addActionListener { onExportTemplates() }

--- a/src/com/abeade/plugin/fcm/push/utils/CustomEditorField.kt
+++ b/src/com/abeade/plugin/fcm/push/utils/CustomEditorField.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.project.Project
 import com.intellij.ui.LanguageTextField
 
-class CustomEditorField(language: Language, project: Project?, s: String) : LanguageTextField(language, project, s) {
+class CustomEditorField(language: Language, project: Project, s: String) : LanguageTextField(language, project, s) {
 
     override fun createEditor(): EditorEx =
         super.createEditor().apply {


### PR DESCRIPTION
Uses default project when creating editor in settings panel
Lazy initialization of settings panel in searchable configurable

closes: https://github.com/abeade/fcm-push-plugin/issues/1